### PR TITLE
Fix unity_install.sh

### DIFF
--- a/common/unity_install.sh
+++ b/common/unity_install.sh
@@ -47,6 +47,7 @@ osp_detect_notification() {
 
 # Check if FLAGS are even present. If not, do removal since there's nothing to patch
 PATCH=false
+REMV=false
 for FILE in ${POLS}; do
   case $FILE in
     *.xml) [ "$(grep 'flags="AUDIO_OUTPUT_FLAG' $FILE)" ] && { PATCH=true; break; };;
@@ -98,6 +99,8 @@ ui_print " "
 if [ -z $PATCH ]; then
   ui_print "  Do you want to patch or remove acp?"
   ui_print "  Vol+ = yes, Vol- = no"
+  PATCH=false
+  REMV=false
   if $VKSEL; then
     ui_print "- Select Patch Method -"
     ui_print "   Patch flags or remove sections?:"
@@ -121,6 +124,8 @@ ui_print " "
 if [ -z $NOTIF ]; then
   ui_print "  Would you like to remove notification_helper or volume listener library?"
   ui_print "  Vol+ = yes, Vol- = no"
+  NOTIF=false
+  VOLU=false
   if $VKSEL; then
     ui_print "- Select Fix Method -"
     ui_print "   Remove Notification Helper Effect or Volume Listener Library?:"
@@ -144,6 +149,7 @@ ui_print " "
 if [ -z $USB ]; then
   ui_print "  Would you like to patch usb policy file for usb dacs?"
   ui_print "  Vol+ = yes, Vol- = no"
+  USB=false
   if $VKSEL; then
     USB=true
   else
@@ -160,6 +166,7 @@ if [ -z $LIBWA ]; then
   ui_print " "
   ui_print "   Only choose yes if you're having issues"
   ui_print "   Vol+ = yes, Vol- = no (recommended)"
+  LIBWA=false
   if $VKSEL; then
     LIBWA=true
   else
@@ -182,7 +189,7 @@ fi
 ui_print "   Patching existing audio policy files..."
 if $PATCH; then
 sed -i "s|PATCH=false|PATCH=true|" $TMPDIR/common/aml.sh
-sed -i "s|patch=false|patch=true|" $TMPDIR/module.propp
+sed -i "s|patch=false|patch=true|" $TMPDIR/module.prop
   ui_print "   Using patch logic"
   for OFILE in ${POLS}; do
     FILE="$UNITY$(echo $OFILE | sed "s|^/vendor|/system/vendor|g")"


### PR DESCRIPTION
I pressed Vol Up to remove notification_helper_effect but the magisk install log said both 'Patching existing audio effects configs...' and 'Removing volume listener library...'. It also said both 'Using patch logic' and 'Using remove logic'. [magisk_install_log](https://del.dog/iparamomot.sql)

Some variables (e.g. `NOTIF` and `VOLU`) are not initialized. The vol key test will set one of them (e.g. `NOTIF=true`). But since `VOLU` is not initialized, both `if $NOTIF` and `if $VOLU` will be true (info here: https://stackoverflow.com/questions/2953646/how-to-declare-and-use-boolean-variables-in-shell-script/21210966#21210966). Both cases will execute, as shown in the magisk install log. This applies to other variables as well. I edited unity_install.sh to initialize all the relevant variables and the above problem doesn't happen.

You'll probably find a better way to do this but this is what I did.

Also fixed a typo (`module.propp`)